### PR TITLE
Add variable to adjust font-family of the CodeMirror container

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
           "no-plusplus": "off",
           "no-param-reassing": "off",
           "class-methods-use-this": "off",
-          "import/no-extraneous-dependencies": "off"
+          "import/no-extraneous-dependencies": "off",
+          "no-return-await": "off"
         }
       }
     ]

--- a/src/CmStyles.js
+++ b/src/CmStyles.js
@@ -51,7 +51,7 @@ import { css } from 'lit-element';
 export default css`
 .CodeMirror {
   /* Set height, width, borders, and global font properties here */
-  font-family: monospace;
+  font-family: var(--code-mirror-font-family, monospace);
   color: inherit;
   background-color: inherit;
   direction: var(--code-mirror-direction, ltr);

--- a/test/code-mirror.test.js
+++ b/test/code-mirror.test.js
@@ -69,22 +69,22 @@ describe('<code-mirror>', function() {
       assert.equal(spy_.args[0][0].detail.value, word);
     });
 
-    it('dispatches before-change event', async () => {
+    it('dispatches beforechange event', async () => {
       const editor = await basicFixture();
       const word = 'TEST';
       const spy_ = spy();
-      editor.addEventListener('before-change', spy_);
+      editor.addEventListener('beforechange', spy_);
       editor.value = word;
       assert.ok(spy_.args[0][0].detail.change);
     });
 
-    it('cancels value change when before-change event is cancelled', async () => {
+    it('cancels value change when beforechange event is cancelled', async () => {
       const editor = await basicFixture();
       const word = 'TEST';
       const clb = function(e) {
         e.detail.change.cancel();
       };
-      editor.addEventListener('before-change', clb);
+      editor.addEventListener('beforechange', clb);
       editor.value = word;
       await aTimeout();
       assert.equal(editor.value, editor.editor.getValue());


### PR DESCRIPTION
While the entire API console uses Consolas and other fallbacks, the code mirror container uses monospace only. Add the `--code-mirror-font-family` variable to make it possible to align the font-family with the API console.